### PR TITLE
Prioritize defaultText over value in docs

### DIFF
--- a/docs.go
+++ b/docs.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"regexp"
 	"runtime"
 	"sort"
@@ -564,23 +563,5 @@ func getFlagDefaultValue(f cli.DocGenerationFlag) string {
 	if !f.TakesValue() {
 		return ""
 	}
-
-	var ref = reflect.ValueOf(f)
-	if ref.Kind() == reflect.Ptr {
-		ref = ref.Elem()
-	}
-
-	if ref.Kind() != reflect.Struct {
-		return ""
-	}
-
-	if defaultTextVal := ref.FieldByName("DefaultText"); defaultTextVal.IsValid() && defaultTextVal.Kind() == reflect.String && defaultTextVal.String() != "" {
-		return defaultTextVal.String()
-	}
-
-	if val := ref.FieldByName("Value"); val.IsValid() && val.Type().Kind() != reflect.Bool {
-		return fmt.Sprintf("%v", val.Interface())
-	}
-
-	return ""
+	return f.GetDefaultText()
 }

--- a/docs.go
+++ b/docs.go
@@ -565,19 +565,17 @@ func getFlagDefaultValue(f cli.DocGenerationFlag) string {
 		return ""
 	}
 
-	if v, ok := f.(interface{ GetValue() string }); ok {
-		return v.GetValue()
-	}
-
 	var ref = reflect.ValueOf(f)
-	if ref.Kind() != reflect.Ptr {
-		return ""
-	} else {
+	if ref.Kind() == reflect.Ptr {
 		ref = ref.Elem()
 	}
 
 	if ref.Kind() != reflect.Struct {
 		return ""
+	}
+
+	if defaultTextVal := ref.FieldByName("DefaultText"); defaultTextVal.IsValid() && defaultTextVal.Kind() == reflect.String && defaultTextVal.String() != "" {
+		return defaultTextVal.String()
 	}
 
 	if val := ref.FieldByName("Value"); val.IsValid() && val.Type().Kind() != reflect.Bool {

--- a/docs_test.go
+++ b/docs_test.go
@@ -3,6 +3,7 @@ package docs
 import (
 	"bytes"
 	"embed"
+	"fmt"
 	"io"
 	"io/fs"
 	"net/mail"
@@ -61,6 +62,11 @@ func buildExtendedTestCommand() *cli.Command {
 			&cli.BoolFlag{
 				Name:   "hidden-flag",
 				Hidden: true,
+			},
+			&cli.StringFlag{
+				Name:        "dir",
+				Value:       pwd(),
+				DefaultText: "$PWD",
 			},
 		},
 		Commands: []*cli.Command{{
@@ -180,6 +186,14 @@ func TestToTabularMarkdown(t *testing.T) {
 		require.NoError(t, err)
 		expectFileContent(t, "testdata/expected-tabular-markdown-custom-app-path.md", res)
 	})
+}
+
+func pwd() string {
+	pwd, err := os.Getwd()
+	if err != nil {
+		fmt.Println(err)
+	}
+	return pwd
 }
 
 func TestToTabularMarkdownFailed(t *testing.T) {

--- a/docs_test.go
+++ b/docs_test.go
@@ -24,8 +24,8 @@ func expectFileContent(t *testing.T, file, got string) {
 	r := require.New(t)
 	r.NoError(err)
 	r.Equal(
-		string(normalizeNewlines([]byte(got))),
 		string(normalizeNewlines(data)),
+		string(normalizeNewlines([]byte(got))),
 	)
 }
 
@@ -45,11 +45,12 @@ func buildExtendedTestCommand() *cli.Command {
 		Name:   "greet",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:      "socket",
-				Aliases:   []string{"s"},
-				Usage:     "some 'usage' text",
-				Value:     "value",
-				TakesFile: true,
+				Name:        "socket",
+				Aliases:     []string{"s"},
+				Usage:       "some 'usage' text",
+				Value:       "value",
+				DefaultText: "value",
+				TakesFile:   true,
 			},
 			&cli.StringFlag{Name: "flag", Aliases: []string{"fl", "f"}},
 			&cli.BoolFlag{
@@ -65,7 +66,7 @@ func buildExtendedTestCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:        "dir",
 				Value:       pwd(),
-				DefaultText: "\".\"",
+				DefaultText: ".",
 			},
 		},
 		Commands: []*cli.Command{{

--- a/docs_test.go
+++ b/docs_test.go
@@ -3,7 +3,6 @@ package docs
 import (
 	"bytes"
 	"embed"
-	"fmt"
 	"io"
 	"io/fs"
 	"net/mail"
@@ -189,10 +188,7 @@ func TestToTabularMarkdown(t *testing.T) {
 }
 
 func pwd() string {
-	pwd, err := os.Getwd()
-	if err != nil {
-		fmt.Println(err)
-	}
+	pwd, _ := os.Getwd()
 	return pwd
 }
 

--- a/docs_test.go
+++ b/docs_test.go
@@ -65,7 +65,7 @@ func buildExtendedTestCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:        "dir",
 				Value:       pwd(),
-				DefaultText: "$PWD",
+				DefaultText: "\".\"",
 			},
 		},
 		Commands: []*cli.Command{{

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -45,7 +45,7 @@ app [first_arg] [second_arg]
 \fB--another-flag, -b\fP: another usage text
 
 .PP
-\fB--dir\fP="":  (default: $PWD)
+\fB--dir\fP="":  (default: ".")
 
 .PP
 \fB--flag, --fl, -f\fP="":

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -45,7 +45,7 @@ app [first_arg] [second_arg]
 \fB--another-flag, -b\fP: another usage text
 
 .PP
-\fB--dir\fP="":  (default: ".")
+\fB--dir\fP="":  (default: .)
 
 .PP
 \fB--flag, --fl, -f\fP="":

--- a/testdata/expected-doc-full.man
+++ b/testdata/expected-doc-full.man
@@ -15,6 +15,7 @@ greet
 
 .nf
 [--another-flag|-b]
+[--dir]=[value]
 [--flag|--fl|-f]=[value]
 [--socket|-s]=[value]
 
@@ -42,6 +43,9 @@ app [first_arg] [second_arg]
 .SH GLOBAL OPTIONS
 .PP
 \fB--another-flag, -b\fP: another usage text
+
+.PP
+\fB--dir\fP="":  (default: $PWD)
 
 .PP
 \fB--flag, --fl, -f\fP="":

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -27,7 +27,7 @@ app [first_arg] [second_arg]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: $PWD)
+**--dir**="":  (default: ".")
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -27,7 +27,7 @@ app [first_arg] [second_arg]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: ".")
+**--dir**="":  (default: .)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-full.md
+++ b/testdata/expected-doc-full.md
@@ -8,6 +8,7 @@ greet
 
 ```
 [--another-flag|-b]
+[--dir]=[value]
 [--flag|--fl|-f]=[value]
 [--socket|-s]=[value]
 ```
@@ -25,6 +26,8 @@ app [first_arg] [second_arg]
 # GLOBAL OPTIONS
 
 **--another-flag, -b**: another usage text
+
+**--dir**="":  (default: $PWD)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -27,7 +27,7 @@ app [first_arg] [second_arg]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: $PWD)
+**--dir**="":  (default: ".")
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -27,7 +27,7 @@ app [first_arg] [second_arg]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: ".")
+**--dir**="":  (default: .)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-authors.md
+++ b/testdata/expected-doc-no-authors.md
@@ -8,6 +8,7 @@ greet
 
 ```
 [--another-flag|-b]
+[--dir]=[value]
 [--flag|--fl|-f]=[value]
 [--socket|-s]=[value]
 ```
@@ -25,6 +26,8 @@ app [first_arg] [second_arg]
 # GLOBAL OPTIONS
 
 **--another-flag, -b**: another usage text
+
+**--dir**="":  (default: $PWD)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-commands.md
+++ b/testdata/expected-doc-no-commands.md
@@ -27,7 +27,7 @@ app [first_arg] [second_arg]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: $PWD)
+**--dir**="":  (default: ".")
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-commands.md
+++ b/testdata/expected-doc-no-commands.md
@@ -27,7 +27,7 @@ app [first_arg] [second_arg]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: ".")
+**--dir**="":  (default: .)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-commands.md
+++ b/testdata/expected-doc-no-commands.md
@@ -8,6 +8,7 @@ greet
 
 ```
 [--another-flag|-b]
+[--dir]=[value]
 [--flag|--fl|-f]=[value]
 [--socket|-s]=[value]
 ```
@@ -25,6 +26,8 @@ app [first_arg] [second_arg]
 # GLOBAL OPTIONS
 
 **--another-flag, -b**: another usage text
+
+**--dir**="":  (default: $PWD)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-usagetext.md
+++ b/testdata/expected-doc-no-usagetext.md
@@ -27,7 +27,7 @@ greet [GLOBAL OPTIONS] [command [COMMAND OPTIONS]] [ARGUMENTS...]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: $PWD)
+**--dir**="":  (default: ".")
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-usagetext.md
+++ b/testdata/expected-doc-no-usagetext.md
@@ -8,6 +8,7 @@ greet
 
 ```
 [--another-flag|-b]
+[--dir]=[value]
 [--flag|--fl|-f]=[value]
 [--socket|-s]=[value]
 ```
@@ -25,6 +26,8 @@ greet [GLOBAL OPTIONS] [command [COMMAND OPTIONS]] [ARGUMENTS...]
 # GLOBAL OPTIONS
 
 **--another-flag, -b**: another usage text
+
+**--dir**="":  (default: $PWD)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-doc-no-usagetext.md
+++ b/testdata/expected-doc-no-usagetext.md
@@ -27,7 +27,7 @@ greet [GLOBAL OPTIONS] [command [COMMAND OPTIONS]] [ARGUMENTS...]
 
 **--another-flag, -b**: another usage text
 
-**--dir**="":  (default: ".")
+**--dir**="":  (default: .)
 
 **--flag, --fl, -f**="": 
 

--- a/testdata/expected-tabular-markdown-custom-app-path.md
+++ b/testdata/expected-tabular-markdown-custom-app-path.md
@@ -19,6 +19,7 @@ Global flags:
 | `--socket="…"` (`-s`)       | some 'usage' text  |    `value`    |         *none*          |
 | `--flag="…"` (`--fl`, `-f`) |                    |               |         *none*          |
 | `--another-flag` (`-b`)     | another usage text |    `false`    | `EXAMPLE_VARIABLE_NAME` |
+| `--dir="…"`                 |                    |    `$PWD`     |         *none*          |
 
 ### `config` command (aliases: `c`)
 

--- a/testdata/expected-tabular-markdown-custom-app-path.md
+++ b/testdata/expected-tabular-markdown-custom-app-path.md
@@ -19,7 +19,7 @@ Global flags:
 | `--socket="…"` (`-s`)       | some 'usage' text  |    `value`    |         *none*          |
 | `--flag="…"` (`--fl`, `-f`) |                    |               |         *none*          |
 | `--another-flag` (`-b`)     | another usage text |    `false`    | `EXAMPLE_VARIABLE_NAME` |
-| `--dir="…"`                 |                    |     `"."`     |         *none*          |
+| `--dir="…"`                 |                    |      `.`      |         *none*          |
 
 ### `config` command (aliases: `c`)
 

--- a/testdata/expected-tabular-markdown-custom-app-path.md
+++ b/testdata/expected-tabular-markdown-custom-app-path.md
@@ -19,7 +19,7 @@ Global flags:
 | `--socket="…"` (`-s`)       | some 'usage' text  |    `value`    |         *none*          |
 | `--flag="…"` (`--fl`, `-f`) |                    |               |         *none*          |
 | `--another-flag` (`-b`)     | another usage text |    `false`    | `EXAMPLE_VARIABLE_NAME` |
-| `--dir="…"`                 |                    |    `$PWD`     |         *none*          |
+| `--dir="…"`                 |                    |     `"."`     |         *none*          |
 
 ### `config` command (aliases: `c`)
 

--- a/testdata/expected-tabular-markdown-full.md
+++ b/testdata/expected-tabular-markdown-full.md
@@ -19,6 +19,7 @@ Global flags:
 | `--socket="…"` (`-s`)       | some 'usage' text  |    `value`    |         *none*          |
 | `--flag="…"` (`--fl`, `-f`) |                    |               |         *none*          |
 | `--another-flag` (`-b`)     | another usage text |    `false`    | `EXAMPLE_VARIABLE_NAME` |
+| `--dir="…"`                 |                    |    `$PWD`     |         *none*          |
 
 ### `config` command (aliases: `c`)
 

--- a/testdata/expected-tabular-markdown-full.md
+++ b/testdata/expected-tabular-markdown-full.md
@@ -19,7 +19,7 @@ Global flags:
 | `--socket="…"` (`-s`)       | some 'usage' text  |    `value`    |         *none*          |
 | `--flag="…"` (`--fl`, `-f`) |                    |               |         *none*          |
 | `--another-flag` (`-b`)     | another usage text |    `false`    | `EXAMPLE_VARIABLE_NAME` |
-| `--dir="…"`                 |                    |     `"."`     |         *none*          |
+| `--dir="…"`                 |                    |      `.`      |         *none*          |
 
 ### `config` command (aliases: `c`)
 

--- a/testdata/expected-tabular-markdown-full.md
+++ b/testdata/expected-tabular-markdown-full.md
@@ -19,7 +19,7 @@ Global flags:
 | `--socket="…"` (`-s`)       | some 'usage' text  |    `value`    |         *none*          |
 | `--flag="…"` (`--fl`, `-f`) |                    |               |         *none*          |
 | `--another-flag` (`-b`)     | another usage text |    `false`    | `EXAMPLE_VARIABLE_NAME` |
-| `--dir="…"`                 |                    |    `$PWD`     |         *none*          |
+| `--dir="…"`                 |                    |     `"."`     |         *none*          |
 
 ### `config` command (aliases: `c`)
 


### PR DESCRIPTION
In cases where the default value is dynamic or programmatic, it'd be nice to be able to align the docs with the help text.

https://cli.urfave.org/v3/examples/flags/advanced/#default-values-for-help-output
