### PR TITLE
remove "Environment variables" if all are none

### DIFF
--- a/markdown_tabular.md.gotmpl
+++ b/markdown_tabular.md.gotmpl
@@ -1,12 +1,20 @@
 {{ define "flags" }}
-| Name | Description | Type | Default value | Environment variables |
-|------|-------------|------|:-------------:|:---------------------:|
+{{- $hasEnvVars := false -}}
+{{- range . -}}
+{{- if and (not $hasEnvVars) .EnvVars -}}
+{{- $hasEnvVars = true -}}
+{{- end -}}
+{{- end }}
+| Name | Description | Type | Default value {{ if $hasEnvVars }}| Environment variables {{ end }}|
+|------|-------------|------|:-------------:{{ if $hasEnvVars }}|:---------------------:{{ end }}|
 {{   range $flag := . -}}
 {{- /**/ -}} | `{{ $flag.Name }}{{ if $flag.TakesValue }}="…"{{ end }}` {{ if $flag.Aliases }}(`{{ join $flag.Aliases "`, `" }}`) {{ end }}
 {{- /**/ -}} | {{ $flag.Usage }}
 {{- /**/ -}} | {{ $flag.Type }}
 {{- /**/ -}} | {{ if $flag.Default }}`{{ $flag.Default }}`{{ end }}
+{{- if $hasEnvVars -}}
 {{- /**/ -}} | {{ if $flag.EnvVars }}`{{ join $flag.EnvVars "`, `" }}`{{ else }}*none*{{ end }}
+{{- end -}}
 {{- /**/ -}} |
 {{   end }}
 {{ end }}

--- a/testdata/expected-tabular-markdown-custom-app-path.md
+++ b/testdata/expected-tabular-markdown-custom-app-path.md
@@ -32,10 +32,10 @@ $ /usr/local/bin [GLOBAL FLAGS] config [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                        | Description        | Type   | Default value | Environment variables |
-|-----------------------------|--------------------|--------|:-------------:|:---------------------:|
-| `--flag="…"` (`--fl`, `-f`) |                    | string |               |        *none*         |
-| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |        *none*         |
+| Name                        | Description        | Type   | Default value |
+|-----------------------------|--------------------|--------|:-------------:|
+| `--flag="…"` (`--fl`, `-f`) |                    | string |
+| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |
 
 ### `config sub-config` subcommand (aliases: `s`, `ss`)
 
@@ -49,10 +49,10 @@ $ /usr/local/bin [GLOBAL FLAGS] config sub-config [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                                | Description     | Type   | Default value | Environment variables |
-|-------------------------------------|-----------------|--------|:-------------:|:---------------------:|
-| `--sub-flag="…"` (`--sub-fl`, `-s`) |                 | string |               |        *none*         |
-| `--sub-command-flag` (`-s`)         | some usage text | bool   |    `false`    |        *none*         |
+| Name                                | Description     | Type   | Default value |
+|-------------------------------------|-----------------|--------|:-------------:|
+| `--sub-flag="…"` (`--sub-fl`, `-s`) |                 | string |
+| `--sub-command-flag` (`-s`)         | some usage text | bool   |    `false`    |
 
 ### `info` command (aliases: `i`, `in`)
 
@@ -93,10 +93,10 @@ $ /usr/local/bin [GLOBAL FLAGS] usage [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                        | Description        | Type   | Default value | Environment variables |
-|-----------------------------|--------------------|--------|:-------------:|:---------------------:|
-| `--flag="…"` (`--fl`, `-f`) |                    | string |               |        *none*         |
-| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |        *none*         |
+| Name                        | Description        | Type   | Default value |
+|-----------------------------|--------------------|--------|:-------------:|
+| `--flag="…"` (`--fl`, `-f`) |                    | string |
+| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |
 
 ### `usage sub-usage` subcommand (aliases: `su`)
 
@@ -112,6 +112,6 @@ $ /usr/local/bin [GLOBAL FLAGS] usage sub-usage [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                        | Description     | Type | Default value | Environment variables |
-|-----------------------------|-----------------|------|:-------------:|:---------------------:|
-| `--sub-command-flag` (`-s`) | some usage text | bool |    `false`    |        *none*         |
+| Name                        | Description     | Type | Default value |
+|-----------------------------|-----------------|------|:-------------:|
+| `--sub-command-flag` (`-s`) | some usage text | bool |    `false`    |

--- a/testdata/expected-tabular-markdown-full.md
+++ b/testdata/expected-tabular-markdown-full.md
@@ -32,10 +32,10 @@ $ app [GLOBAL FLAGS] config [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                        | Description        | Type   | Default value | Environment variables |
-|-----------------------------|--------------------|--------|:-------------:|:---------------------:|
-| `--flag="…"` (`--fl`, `-f`) |                    | string |               |        *none*         |
-| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |        *none*         |
+| Name                        | Description        | Type   | Default value |
+|-----------------------------|--------------------|--------|:-------------:|
+| `--flag="…"` (`--fl`, `-f`) |                    | string |
+| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |
 
 ### `config sub-config` subcommand (aliases: `s`, `ss`)
 
@@ -49,10 +49,10 @@ $ app [GLOBAL FLAGS] config sub-config [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                                | Description     | Type   | Default value | Environment variables |
-|-------------------------------------|-----------------|--------|:-------------:|:---------------------:|
-| `--sub-flag="…"` (`--sub-fl`, `-s`) |                 | string |               |        *none*         |
-| `--sub-command-flag` (`-s`)         | some usage text | bool   |    `false`    |        *none*         |
+| Name                                | Description     | Type   | Default value |
+|-------------------------------------|-----------------|--------|:-------------:|
+| `--sub-flag="…"` (`--sub-fl`, `-s`) |                 | string |
+| `--sub-command-flag` (`-s`)         | some usage text | bool   |    `false`    |
 
 ### `info` command (aliases: `i`, `in`)
 
@@ -93,10 +93,10 @@ $ app [GLOBAL FLAGS] usage [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                        | Description        | Type   | Default value | Environment variables |
-|-----------------------------|--------------------|--------|:-------------:|:---------------------:|
-| `--flag="…"` (`--fl`, `-f`) |                    | string |               |        *none*         |
-| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |        *none*         |
+| Name                        | Description        | Type   | Default value |
+|-----------------------------|--------------------|--------|:-------------:|
+| `--flag="…"` (`--fl`, `-f`) |                    | string |
+| `--another-flag` (`-b`)     | another usage text | bool   |    `false`    |
 
 ### `usage sub-usage` subcommand (aliases: `su`)
 
@@ -112,6 +112,6 @@ $ app [GLOBAL FLAGS] usage sub-usage [COMMAND FLAGS] [ARGUMENTS...]
 
 The following flags are supported:
 
-| Name                        | Description     | Type | Default value | Environment variables |
-|-----------------------------|-----------------|------|:-------------:|:---------------------:|
-| `--sub-command-flag` (`-s`) | some usage text | bool |    `false`    |        *none*         |
+| Name                        | Description     | Type | Default value |
+|-----------------------------|-----------------|------|:-------------:|
+| `--sub-command-flag` (`-s`) | some usage text | bool |    `false`    |


### PR DESCRIPTION
Some commands may not use environment variables for their flags so we can drop the column in this case.